### PR TITLE
added __need_timespec macro to make sure timespec struct was defined

### DIFF
--- a/src/hirlite.c
+++ b/src/hirlite.c
@@ -8,6 +8,7 @@
 #include <string.h>
 #include <strings.h>
 #include <sys/time.h>
+#define __need_timespec
 #include <time.h>
 #include <unistd.h>
 


### PR DESCRIPTION
When compiling on Void Linux with glibc version 2.24_4, the compilation was failing because the `timespec` struct wasn't defined. I added the macro needed to define it.

Relevant part of `time.h` for reference:

```
#if (!defined __timespec_defined                                        \
     && ((defined _TIME_H                                               \
          && (defined __USE_POSIX199309                                 \
              || defined __USE_ISOC11))                                 \
         || defined __need_timespec))
# define __timespec_defined     1

# include <bits/types.h>        /* This defines __time_t for us.  */

/* POSIX.1b structure for a time value.  This is like a `struct timeval' but
   has nanoseconds instead of microseconds.  */
struct timespec
  {
    __time_t tv_sec;            /* Seconds.  */
    __syscall_slong_t tv_nsec;  /* Nanoseconds.  */
  };

#endif /* timespec not defined and <time.h> or need timespec.  */
#undef  __need_timespec
```