### PR TITLE
Fix for clock support issue

### DIFF
--- a/src/hirlite.c
+++ b/src/hirlite.c
@@ -1,3 +1,4 @@
+#define _POSIX_C_SOURCE 199309L
 #include <stdio.h>
 #include "rlite/constants.h"
 #include <assert.h>


### PR DESCRIPTION
This PR fixes the [clock support issue described here](https://github.com/seppo0010/rlite/issues/40), which gives the error "Error: storage size of ‘tv’ isn’t known". This was preventing compilation on Ubuntu 18.04 (and probably other systems). The fix was discovered in this [Stack Overflow comment](https://stackoverflow.com/questions/42597685/storage-size-of-timespec-isnt-known/42606673#42606673) given for a similar error.